### PR TITLE
Add unit tests for runner routes and service

### DIFF
--- a/server/routes/__tests__/runner-routes.test.ts
+++ b/server/routes/__tests__/runner-routes.test.ts
@@ -1,0 +1,102 @@
+import { registerRunnerRoutes } from '../runner-routes';
+import { RunnerService } from '../../services/runner-service';
+import express from 'express';
+import request from 'supertest';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { Runner } from '@prisma/client';
+
+let runnerService: MockProxy<RunnerService> & RunnerService;
+let app: express.Express;
+
+let runners: Runner[] = [
+    { 
+        id: 1,
+        name: 'Runner One',
+    },
+    { 
+        id: 2,
+        name: 'Runner Two',
+    },
+];
+
+beforeEach(() => {
+    runnerService = mock<RunnerService>();
+
+    app = express();
+    app.use(express.json());
+    app.use(registerRunnerRoutes(runnerService));
+});
+
+describe('Runner routes', () => {
+    describe('GET /', () => {
+        test('returns all runners', async () => {
+            runnerService.getAll.mockResolvedValue(runners);
+
+            const response = await request(app).get('');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual(runners);
+        });
+
+        test('returns 500 if error getting data', async () => {
+            runnerService.getAll.mockRejectedValue('error');
+
+            const response = await request(app).get('');
+
+            expect(response.status).toBe(500);
+        });
+    });
+
+    describe('GET /search/:name', () => {
+        test('returns runners by name', async () => {
+            const runner = runners[0];
+            const nameSearchRunners = [runner];
+            runnerService.getByName.mockResolvedValue(nameSearchRunners);
+            const name = runner.name;
+
+            const response = await request(app).get(`/search/${name}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual(nameSearchRunners);
+        });
+
+        test('returns 500 if error getting data', async () => {
+            runnerService.getByName.mockRejectedValue('error');
+            const name = runners[0].name;
+
+            const response = await request(app).get(`/search/${name}`);
+
+            expect(response.status).toBe(500);
+        });
+    });
+
+    describe('GET /:id', () => {
+        test('returns runner by id', async () => {
+            const runner = runners[0];
+            runnerService.getById.mockResolvedValue(runner);
+
+            const response = await request(app).get(`/${runner.id}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual(runner);
+        });
+
+        test('returns 404 if runner not found', async () => {
+            const id = 1;
+            runnerService.getById.mockResolvedValue(null);
+
+            const response = await request(app).get(`/${id}`);
+
+            expect(response.status).toBe(404);
+        });
+
+        test('returns 500 if error getting data', async () => {
+            const id = 1;
+            runnerService.getById.mockRejectedValue('error');
+
+            const response = await request(app).get(`/${id}`);
+
+            expect(response.status).toBe(500);
+        });
+    });
+});

--- a/server/services/tests/runner-service.test.ts
+++ b/server/services/tests/runner-service.test.ts
@@ -1,0 +1,61 @@
+import { MockContext, createMockContext } from './mock-context';
+import { RunnerService } from '../runner-service';
+import { Runner } from '@prisma/client';
+
+let mockContext: MockContext;
+let runnerService: RunnerService;
+let runners: Runner[];
+
+beforeEach(() => {
+    mockContext = createMockContext();
+    runnerService = new RunnerService(mockContext.prisma);
+    runners = [
+        { id: 1, name: 'Runner One' },
+        { id: 2, name: 'Runner Two' }
+    ];
+});
+
+describe('RunnerService', () => {
+    describe('getAll', () => {
+        test('should return all runners', async () => {
+            mockContext.prisma.runner.findMany.mockResolvedValue(runners);
+            const result = await runnerService.getAll();
+            expect(result).toEqual(runners);
+            expect(mockContext.prisma.runner.findMany).toHaveBeenCalled();
+        });
+
+        test('should handle errors', async () => {
+            mockContext.prisma.runner.findMany.mockRejectedValue(new Error('Error fetching runners'));
+            await expect(runnerService.getAll()).rejects.toThrow('Error fetching runners');
+        });
+    });
+
+    describe('getById', () => {
+        test('should return a runner by id', async () => {
+            const runner = runners[0];
+            mockContext.prisma.runner.findUnique.mockResolvedValue(runner);
+            const result = await runnerService.getById(runner.id);
+            expect(result).toEqual(runner);
+            expect(mockContext.prisma.runner.findUnique).toHaveBeenCalledWith({ where: { id: runner.id } });
+        });
+
+        test('should handle errors', async () => {
+            mockContext.prisma.runner.findUnique.mockRejectedValue(new Error('Error fetching runner by id'));
+            await expect(runnerService.getById(1)).rejects.toThrow('Error fetching runner by id');
+        });
+    });
+
+    describe('getByName', () => {
+        test('should return runners by name', async () => {
+            mockContext.prisma.runner.findMany.mockResolvedValue([runners[0]]);
+            const result = await runnerService.getByName('Runner One');
+            expect(result).toEqual([runners[0]]);
+            expect(mockContext.prisma.runner.findMany).toHaveBeenCalledWith({ where: { name: { startsWith: 'Runner One' } } });
+        });
+
+        test('should handle errors', async () => {
+            mockContext.prisma.runner.findMany.mockRejectedValue(new Error('Error fetching runners by name'));
+            await expect(runnerService.getByName('Runner One')).rejects.toThrow('Error fetching runners by name');
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces unit tests for the `RunnerService` and runner routes, enhancing the test coverage for these components.

- **Adds unit tests for `RunnerService` methods (`getAll`, `getById`, `getByName`):**
  - Utilizes `jest-mock-extended` to mock the Prisma client, ensuring that the service methods are correctly interacting with the database.
  - Tests both success and error scenarios, verifying that the service methods handle errors gracefully and return the expected results.

- **Implements unit tests for runner routes (`GET /`, `GET /search/:name`, `GET /:id`):**
  - Uses `supertest` for HTTP assertions, ensuring that each endpoint responds correctly under various scenarios.
  - Mocks `RunnerService` methods to test the routes in isolation, checking for correct status codes and response bodies.
  - Covers both success and failure cases, including error handling and edge cases like non-existent runners.

These tests aim to ensure the reliability and correctness of the `RunnerService` and its associated routes, providing a safety net for future development and refactoring.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/octocademy/runner-tracker/pull/3?shareId=55305903-c0b3-481f-bcbb-2fa9686cb027).